### PR TITLE
distributed apps/camera_pipe

### DIFF
--- a/apps/camera_pipe/CMakeLists.txt
+++ b/apps/camera_pipe/CMakeLists.txt
@@ -11,6 +11,9 @@ set(CMAKE_CXX_EXTENSIONS NO)
 # Find Halide
 find_package(Halide REQUIRED)
 
+# Find MPI
+find_package(MPI REQUIRED)
+
 # Generator
 add_executable(camera_pipe.generator camera_pipe_generator.cpp)
 target_link_libraries(camera_pipe.generator
@@ -25,7 +28,7 @@ add_halide_library(camera_pipe_auto_schedule FROM camera_pipe.generator
                    AUTOSCHEDULER Halide::Mullapudi2016)
 
 # Main executable
-add_executable(camera_pipe_process process.cpp)
+add_executable(camera_pipe_process process.cpp distributed.cpp distributed.h)
 target_link_libraries(camera_pipe_process
                       PRIVATE
                       Halide::ImageIO

--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -10,7 +10,7 @@ using namespace Halide;
 using namespace Halide::ConciseCasts;
 
 // Shared variables
-Var x, y, c, yi, yo, yii, xi;
+Var x{"x"}, y{"y"}, c{"c"}, xi{"xi"}, xo{"xo"}, xii{"xii"}, yi{"yi"}, yo{"yo"}, yii{"yii"}, tile{"tile"};
 
 // Average two positive values rounding up
 Expr avg(Expr a, Expr b) {
@@ -22,14 +22,14 @@ Expr blur121(Expr a, Expr b, Expr c) {
     return avg(avg(a, c), b);
 }
 
-Func interleave_x(Func a, Func b) {
-    Func out;
+Func interleave_x(std::string name, Func a, Func b) {
+    Func out{name};
     out(x, y) = select((x % 2) == 0, a(x / 2, y), b(x / 2, y));
     return out;
 }
 
-Func interleave_y(Func a, Func b) {
-    Func out;
+Func interleave_y(std::string name, Func a, Func b) {
+    Func out{name};
     out(x, y) = select((y % 2) == 0, a(x, y / 2), b(x, y / 2));
     return out;
 }
@@ -52,7 +52,7 @@ public:
         // gr refers to green sites in the red rows
 
         // Give more convenient names to the four channels we know
-        Func r_r, g_gr, g_gb, b_b;
+        Func r_r{"demosaic_r_r"}, g_gr{"demosaic_g_gr"}, g_gb{"demosaic_g_gb"}, b_b{"demosaic_b_b"};
 
         g_gr(x, y) = deinterleaved(x, y, 0);
         r_r(x, y) = deinterleaved(x, y, 1);
@@ -60,7 +60,8 @@ public:
         g_gb(x, y) = deinterleaved(x, y, 3);
 
         // These are the ones we need to interpolate
-        Func b_r, g_r, b_gr, r_gr, b_gb, r_gb, r_b, g_b;
+        Func b_r{"demosaic_b_r"}, g_r{"demosaic_g_r"}, b_gr{"demosaic_b_gr"}, r_gr{"demosaic_r_gr"},
+             b_gb{"demosaic_b_gb"}, r_gb{"demosaic_r_gb"}, r_b{"demosaic_r_b"}, g_b{"demosaic_g_b"};
 
         // First calculate green at the red and blue sites
 
@@ -130,15 +131,15 @@ public:
         b_r(x, y) = select(bpd_r < bnd_r, bp_r, bn_r);
 
         // Resulting color channels
-        Func r, g, b;
+        Func r{"demosaic_r"}, g{"demosaic_g"}, b{"demosaic_b"};
 
         // Interleave the resulting channels
-        r = interleave_y(interleave_x(r_gr, r_r),
-                         interleave_x(r_b, r_gb));
-        g = interleave_y(interleave_x(g_gr, g_r),
-                         interleave_x(g_b, g_gb));
-        b = interleave_y(interleave_x(b_gr, b_r),
-                         interleave_x(b_b, b_gb));
+        r = interleave_y("interleave_r", interleave_x("interleave_r_g", r_gr, r_r),
+                                         interleave_x("interleave_r_b", r_b, r_gb));
+        g = interleave_y("interleave_g", interleave_x("interleave_g_r", g_gr, g_r),
+                                         interleave_x("interleave_g_b", g_b, g_gb));
+        b = interleave_y("interleave_b", interleave_x("interleave_b_r", b_gr, b_r),
+                                         interleave_x("interleave_b_g", b_b, b_gb));
 
         output(x, y, c) = mux(c, {r(x, y), g(x, y), b(x, y)});
 
@@ -154,7 +155,7 @@ public:
         if (auto_schedule) {
             // blank
         } else if (get_target().has_gpu_feature()) {
-            Var xi, yi;
+            Var xi{"xi"}, yi{"yi"};
             for (Func f : intermediates) {
                 f.compute_at(intermed_compute_at).gpu_threads(x, y);
             }
@@ -240,7 +241,7 @@ Func CameraPipe::hot_pixel_suppression(Func input) {
     Expr a = max(input(x - 2, y), input(x + 2, y),
                  input(x, y - 2), input(x, y + 2));
 
-    Func denoised;
+    Func denoised{"denoised"};
     denoised(x, y) = clamp(input(x, y), 0, a);
 
     return denoised;
@@ -263,7 +264,7 @@ Func CameraPipe::color_correct(Func input) {
     // calibrated matrices using inverse kelvin.
     Expr kelvin = color_temp;
 
-    Func matrix;
+    Func matrix{"color_matrix"};
     Expr alpha = (1.0f / kelvin - 1.0f / 3200) / (1.0f / 7000 - 1.0f / 3200);
     Expr val = (matrix_3200(x, y) * alpha + matrix_7000(x, y) * (1 - alpha));
     matrix(x, y) = cast<int16_t>(val * 256.0f);  // Q8.8 fixed point
@@ -275,7 +276,7 @@ Func CameraPipe::color_correct(Func input) {
         }
     }
 
-    Func corrected;
+    Func corrected{"color_corrected"};
     Expr ir = cast<int32_t>(input(x, y, 0));
     Expr ig = cast<int32_t>(input(x, y, 1));
     Expr ib = cast<int32_t>(input(x, y, 2));
@@ -333,7 +334,7 @@ Func CameraPipe::apply_curve(Func input) {
         // It's a LUT, compute it once ahead of time.
         curve.compute_root();
         if (get_target().has_gpu_feature()) {
-            Var xi;
+            Var xi{"xi"};
             curve.gpu_tile(x, xi, 32);
         }
     }
@@ -346,7 +347,7 @@ Func CameraPipe::apply_curve(Func input) {
         curve.add_trace_tag(cfg.to_trace_tag());
     }
 
-    Func curved;
+    Func curved{"curved"};
 
     if (lutResample == 1) {
         // Use clamp to restrict size of LUT as allocated by compute_root
@@ -407,7 +408,7 @@ void CameraPipe::generate() {
     // to make a 2560x1920 output image, just like the FCam pipe, so
     // shift by 16, 12. We also convert it to be signed, so we can deal
     // with values that fall below 0 during processing.
-    Func shifted;
+    Func shifted{"shifted"};
     shifted(x, y) = cast<int16_t>(input(x + 16, y + 12));
 
     Func denoised = hot_pixel_suppression(shifted);
@@ -453,7 +454,7 @@ void CameraPipe::generate() {
                 .bound(y, 0, (out_height / 2) * 2);
         }
 
-        Var xi, yi, xii, xio;
+        Var xi{"xi"}, yi{"yi"}, xii{"xii"}, xio{"xio"};
 
         /* These tile factors obtain 1391us on a gtx 980. */
         int tile_x = 28;
@@ -470,7 +471,8 @@ void CameraPipe::generate() {
         processed.compute_root()
             .reorder(c, x, y)
             .unroll(x, 2)
-            .gpu_tile(x, y, xi, yi, tile_x, tile_y);
+            .gpu_tile(x, y, xi, yi, tile_x, tile_y)
+            .distribute(y);
 
         curved.compute_at(processed, x)
             .unroll(x, 2)
@@ -505,13 +507,16 @@ void CameraPipe::generate() {
         // stick to 4 threads. On balance, the overhead should
         // not be much for the 2 extra threads that we create
         // on cores that have only two HVX contexts.
-        Expr strip_size;
+        Expr strip_width, strip_height;
         if (get_target().has_feature(Target::HVX)) {
-            strip_size = processed.dim(1).extent() / 4;
+            strip_height = processed.dim(1).extent() / 4;
+            strip_width = processed.dim(0).extent() / 4;
         } else {
-            strip_size = 32;
+            strip_width = 256;
+            strip_height = 32;
         }
-        strip_size = (strip_size / 2) * 2;
+        strip_width = (strip_width / 2) * 2;
+        strip_height = (strip_height / 2) * 2;
 
         int vec = get_target().natural_vector_size(UInt(16));
         if (get_target().has_feature(Target::HVX)) {
@@ -520,15 +525,20 @@ void CameraPipe::generate() {
         processed
             .compute_root()
             .reorder(c, x, y)
+            .split(x, xi, xii, vec)
+            .split(xi, xo, xi, strip_width / 2)
             .split(y, yi, yii, 2, TailStrategy::RoundUp)
-            .split(yi, yo, yi, strip_size / 2)
-            .vectorize(x, 2 * vec, TailStrategy::RoundUp)
+            .split(yi, yo, yi, strip_height / 2)
+            .reorder(c, xii, xi, yii, yi, xo, yo)
+            .vectorize(xii, vec, TailStrategy::RoundUp)
             .unroll(c)
-            .parallel(yo);
+            .fuse(xo, yo, tile)
+            .parallel(tile)
+            .distribute(tile);
 
         denoised
             .compute_at(processed, yi)
-            .store_at(processed, yo)
+            .store_at(processed, yi)
             .prefetch(input, y, 2)
             .fold_storage(y, 16)
             .tile(x, y, x, y, xi, yi, 2 * vec, 2)
@@ -537,7 +547,7 @@ void CameraPipe::generate() {
 
         deinterleaved
             .compute_at(processed, yi)
-            .store_at(processed, yo)
+            .store_at(processed, yi)
             .fold_storage(y, 8)
             .reorder(c, x, y)
             .vectorize(x, 2 * vec, TailStrategy::RoundUp)
@@ -545,7 +555,7 @@ void CameraPipe::generate() {
 
         curved
             .compute_at(processed, yi)
-            .store_at(processed, yo)
+            .store_at(processed, yi)
             .reorder(c, x, y)
             .tile(x, y, x, y, xi, yi, 2 * vec, 2, TailStrategy::RoundUp)
             .vectorize(xi)
@@ -559,7 +569,7 @@ void CameraPipe::generate() {
             .unroll(c);
 
         demosaiced->intermed_compute_at.set({processed, yi});
-        demosaiced->intermed_store_at.set({processed, yo});
+        demosaiced->intermed_store_at.set({processed, yi});
         demosaiced->output_compute_at.set({curved, x});
 
         if (get_target().has_feature(Target::HVX)) {
@@ -572,8 +582,9 @@ void CameraPipe::generate() {
         // We can generate slightly better code if we know the splits divide the extent.
         processed
             .bound(c, 0, 3)
-            .bound(x, 0, ((out_width) / (2 * vec)) * (2 * vec))
-            .bound(y, 0, (out_height / strip_size) * strip_size);
+            // .bound(x, 0, ((out_width) / (2 * vec)) * (2 * vec)) // causes failures with .distribute(tile) above
+            // .bound(y, 0, (out_height / strip_height) * strip_height) // causes failures with .distribute(yo) above
+            ;
 
         /* Optional tags to specify layout for HalideTraceViz */
         {

--- a/apps/camera_pipe/distributed.cpp
+++ b/apps/camera_pipe/distributed.cpp
@@ -1,0 +1,144 @@
+#include <mpi.h>
+#include "distributed.h"
+
+int rank = 0, numranks = 0;
+
+std::vector<MPI_Request*> sends;
+using namespace Halide::Runtime;
+
+void distributed_init(int *argc, char ***argv) {
+    MPI_Init(argc, argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &numranks);
+}
+
+void distributed_done(void) {
+    // wait for outgoing transfers to complete
+    for (MPI_Request *req : sends) {
+        MPI_Wait(req, MPI_STATUS_IGNORE);
+        delete req;
+    }
+    sends.clear();
+
+    MPI_Finalize();
+}
+
+void report_mpi_error(MPI_Status *status, const char *when) {
+    char str[MPI_MAX_ERROR_STRING];
+    int len;
+    MPI_Error_string(status->MPI_ERROR, str, &len);
+    fprintf(stderr, "%s, node %d, status %d (%s)\n", when, status->MPI_SOURCE, status->MPI_ERROR, str);
+    MPI_Abort(MPI_COMM_WORLD, status->MPI_ERROR);
+}
+
+struct node_size {
+    int xmin, xmax;
+    int ymin, ymax;
+    int cmin, cmax;
+};
+
+#define TAG_SIZE(node) (node)
+#define TAG_STRIPE(node) (numranks+node)
+
+Buffer<uint8_t> *gather_to_rank0(Buffer<uint8_t> &output, int full_image_width, int full_image_height) {
+    if(numranks == 1) {
+        // nothing to gather, use the local buffer as-is.
+        return &output;
+    }
+
+    int local_xmin = output.dim(0).min();
+    int local_xmax = output.dim(0).min()+output.dim(0).extent();
+    int local_ymin = output.dim(1).min();
+    int local_ymax = output.dim(1).min()+output.dim(1).extent();
+    int local_cmin = output.dim(2).min();
+    int local_cmax = output.dim(2).min()+output.dim(2).extent();
+    int local_width  = local_xmax - local_xmin;
+    int local_height = local_ymax - local_ymin;
+    int local_colors = local_cmax - local_cmin;
+
+    // each node sends its buffer size to node 0
+    struct node_size my_sizes = {
+        .xmin=local_xmin, .xmax=local_xmax,
+        .ymin=local_ymin, .ymax=local_ymax,
+        .cmin=local_cmin, .cmax=local_cmax
+    };
+
+    struct node_size node_sizes[numranks];
+    MPI_Request node_size_reqs[numranks];
+    MPI_Request *node_size_send = new MPI_Request;
+    // fprintf_rank(stderr, "sending sizes to node 0\n");
+    MPI_Isend(&my_sizes, sizeof(my_sizes), MPI_BYTE, 0, TAG_SIZE(rank), MPI_COMM_WORLD, node_size_send);
+    sends.push_back(node_size_send);
+    if(rank) {
+        // fprintf_rank(stderr, "sending tile data to node 0\n");
+        int len = local_width * local_height * local_colors;
+        assert(len == output.number_of_elements());
+        MPI_Send(output.begin(), len, MPI_BYTE, 0, TAG_STRIPE(rank), MPI_COMM_WORLD);
+    }
+    Buffer<uint8_t> *full_output = NULL;
+    if(!rank) {
+        // asynchronously receive shapes from nodes
+        for(int node = 0; node < numranks; node++) {
+            // fprintf_rank(stderr, "receiving sizes from node %d\n", node);
+            MPI_Irecv(&node_sizes[node], sizeof(my_sizes), MPI_BYTE, node, TAG_SIZE(node), MPI_COMM_WORLD, &node_size_reqs[node]);
+        }
+        fprintf_rank(stderr, "gathering output data\n");
+        full_output = new Buffer<uint8_t>(full_image_width, full_image_height, 3);
+        for(int node = 0; node < numranks; node++) {
+            MPI_Status status;
+            memset(&status, 0, sizeof(status));
+            MPI_Wait(&node_size_reqs[node], &status);
+            if(status.MPI_ERROR) {
+                report_mpi_error(&status, "MPI_Wait receiving sizing data");
+            }
+
+            struct node_size *node_size = &node_sizes[node];
+            int node_width  = node_size->xmax - node_size->xmin;
+            int node_height = node_size->ymax - node_size->ymin;
+            int node_colors = node_size->cmax - node_size->cmin;
+            halide_dimension_t shape[3];
+            shape[0].min = node_size->xmin;
+            shape[1].min = node_size->ymin;
+            shape[2].min = node_size->cmin;
+            shape[0].extent = node_size->xmax - node_size->xmin;
+            shape[1].extent = node_size->ymax - node_size->ymin;
+            shape[2].extent = node_size->cmax - node_size->cmin;
+            int xmin = node_size->xmin;
+            int xlen = node_size->xmax - node_size->xmin;
+            Buffer<uint8_t> *source_buffer;
+            Buffer<uint8_t> node_buffer(NULL, {node_width, node_height, node_colors});
+            if(node == rank) {
+                source_buffer = &output;
+            } else {
+                source_buffer = &node_buffer;
+                node_buffer.allocate();
+                uint8_t *ptr = node_buffer.begin();
+                int buffer_len = node_buffer.number_of_elements();
+                MPI_Status status;
+                memset(&status, 0, sizeof(status));
+                // fprintf_rank(stderr, "receiving tile position [%d,%d,%d] shape [%d,%d,%d] from node %d\n",
+                //              node_size->xmin, node_size->ymin, node_size->cmin,
+                //              node_width, node_height, node_colors, node);
+                MPI_Recv(ptr, buffer_len, MPI_BYTE, node, TAG_STRIPE(node), MPI_COMM_WORLD, &status);
+                if(status.MPI_ERROR) {
+                    report_mpi_error(&status, "MPI_Recv receiving tile data");
+                }
+            }
+            // copy tile data into the output buffer, one row at a time
+            for(int c = 0; c < node_colors; c++) {
+                for(int y = 0; y < node_height; y++) {
+                    uint8_t *outptr = &(*full_output)(xmin, y+node_size->ymin, c+node_size->cmin);
+                    uint8_t *tmpptr = &(*source_buffer)(0, y, c);
+                    // fprintf_rank(stderr, "copying vector (x,%d,%d) of length %d from %p to %p\n",
+                    //              y+node_size->ymin, c+node_size->cmin, xlen, tmpptr, outptr);
+                    memcpy(outptr, tmpptr, xlen);
+                }
+            }
+            node_buffer.deallocate();
+        }
+    }
+
+    // completion of asynchronous sends is handled by distributed_done(), above.
+
+    return full_output;
+}

--- a/apps/camera_pipe/distributed.h
+++ b/apps/camera_pipe/distributed.h
@@ -1,0 +1,18 @@
+#ifndef _DISTRIBUTED_H
+#define _DISTRIBUTED_H
+
+#include <stdio.h>
+#include "HalideBuffer.h"
+
+extern int rank, numranks;
+void distributed_init(int *argc, char ***argv);
+void distributed_done(void);
+Halide::Runtime::Buffer<uint8_t> *gather_to_rank0(Halide::Runtime::Buffer<uint8_t> &output,
+    int full_image_width, int full_image_height);
+
+// only print message on rank 0
+#define fprintf_rank0(a, ...) do { if(!rank) fprintf(a, __VA_ARGS__); } while(0)
+// print with "N: " prefix (where "N" is the node rank)
+#define fprintf_rank(a, b, ...) fprintf(a, "%d: " b, rank, ##__VA_ARGS__)
+
+#endif /* _DISTRIBUTED_H */


### PR DESCRIPTION
This adds distributed operation to the `apps/camera_pipe` app.  It divides the output into tiles, parallelizes and distributes over tiles, gathers the tiles together into a big buffer on node 0 and writes the output image.  The gather step and some of the print statements are skipped when running on only 1 node.

The gather step and some utility functions are added to a new file, `distributed.cpp` and a corresponding header.  This gather code should work with any tiling pattern we come up with.

I have not done any performance tuning on this yet, the tile pattern was chosen arbitrarily.  I found that the `processed.bound()` calls cause errors with distributed operation, so they are commented out for now.

I also gave names to all of the `Var`s and `Func`s in this app, to make error messages easier to understand, as well as the `processed.print_loop_nest()` output and the output of the `profile` feature.
